### PR TITLE
filter disconnected atom mappings

### DIFF
--- a/test_bgl.py
+++ b/test_bgl.py
@@ -16,8 +16,8 @@ def run():
     for idx, mol_a in enumerate(mols):
         for mol_b in mols[idx + 1 :]:
 
-            # all_cores = atom_mapping.get_core(mol_a, mol_b, ring_cutoff=0.1, chain_cutoff=0.0)
-            all_cores = atom_mapping.get_cores(mol_a, mol_b, ring_cutoff=0.1, chain_cutoff=0.2)
+            # all_cores = atom_mapping.get_core(mol_a, mol_b, ring_cutoff=0.1, chain_cutoff=0.0, timeout=60)
+            all_cores = atom_mapping.get_cores(mol_a, mol_b, ring_cutoff=0.1, chain_cutoff=0.2, timeout=60)
             for core_idx, core in enumerate(all_cores[:1]):
                 res = atom_mapping.plot_atom_mapping_grid(mol_a, mol_b, core, num_rotations=5)
 


### PR DESCRIPTION
- Add option to filter out subgraphs of a mapping that are not the largest continuous component
